### PR TITLE
Popping object_list from kwargs with default

### DIFF
--- a/django_actions/views.py
+++ b/django_actions/views.py
@@ -7,7 +7,7 @@ class ActionViewMixin(object):
 
     def get_context_data(self, *args, **kwargs):
         # Saves whole object list (without pagination) for eventual post
-        kwargs['_whole_object_list'] = kwargs['object_list']
+        kwargs['_whole_object_list'] = kwargs.pop('object_list', self.object_list)
         # Actions available in templates
         descriptions = []
         for action in self.actions:


### PR DESCRIPTION
I made this change to get django-actions working with Django version 1.6.5
